### PR TITLE
fix(#1): generate*() 진입부에 식별자 검증(validateName) 적용

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -121,9 +121,9 @@ const ColumnTab = (() => {
     const c = readField('col-add', COL_FIELDS);
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!t.schema) errs.push('스키마명 필수.');
-    if (!t.tableName) errs.push('테이블명 필수.');
-    if (!c.colName) errs.push('컬럼명 필수.');
+    Utils.checkName('스키마명', t.schema, errs);
+    Utils.checkName('테이블명', t.tableName ? Utils.ensurePrefix(t.tableName, 'TB') : '', errs);
+    Utils.checkName('컬럼명', c.colName, errs);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 
@@ -188,7 +188,9 @@ const ColumnTab = (() => {
     const c = readField('col-mod', COL_FIELDS);
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!t.schema || !t.tableName || !c.colName) errs.push('스키마/테이블/컬럼명 모두 필수.');
+    Utils.checkName('스키마명', t.schema, errs);
+    Utils.checkName('테이블명', t.tableName ? Utils.ensurePrefix(t.tableName, 'TB') : '', errs);
+    Utils.checkName('컬럼명', c.colName, errs);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 
@@ -253,7 +255,9 @@ const ColumnTab = (() => {
     const mode = document.getElementById('col-drop-mode').value;
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!schema || !tableName || !colName) errs.push('스키마/테이블/컬럼명 모두 필수.');
+    Utils.checkName('스키마명', schema, errs);
+    Utils.checkName('테이블명', tableName ? Utils.ensurePrefix(tableName, 'TB') : '', errs);
+    Utils.checkName('컬럼명', colName, errs);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 

--- a/js/indexMgr.js
+++ b/js/indexMgr.js
@@ -65,14 +65,14 @@ const IndexTab = (() => {
     const d = readField('idx', ['schema','tableName','indexName','indexTypeCd','purposeCd','indexColumns','tablespaceName','initrans','pctfree','performanceNote']);
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!d.schema) errs.push('스키마명 필수.');
-    if (!d.tableName) errs.push('테이블명 필수.');
+    Utils.checkName('스키마명', d.schema, errs);
+    Utils.checkName('테이블명', d.tableName ? Utils.ensurePrefix(d.tableName, 'TB') : '', errs);
+    if (d.indexName) Utils.checkName('인덱스명', d.indexName, errs);
+    Utils.checkName('테이블스페이스', d.tablespaceName, errs, false);
     if (!d.indexColumns) errs.push('컬럼 목록 필수.');
-    if (errs.length) { UI.showValidation(errs); return; }
-    UI.clearValidation();
 
-    const schema = d.schema.toUpperCase();
-    const tbl    = Utils.ensurePrefix(d.tableName, 'TB');
+    const schema = d.schema ? d.schema.toUpperCase() : '';
+    const tbl    = d.tableName ? Utils.ensurePrefix(d.tableName, 'TB') : '';
     let idxName  = d.indexName ? d.indexName.toUpperCase() : null;
     if (!idxName) {
       const prefix = d.indexTypeCd === 'UNIQUE' ? 'UIX' : 'IX';
@@ -80,7 +80,10 @@ const IndexTab = (() => {
     }
     idxName = Utils.ensurePrefix(idxName, d.indexTypeCd === 'UNIQUE' ? 'UIX' : 'IX');
 
-    const cols = d.indexColumns.split(',').map(s => parseIdxColumn(s)).filter(Boolean);
+    const cols = d.indexColumns ? d.indexColumns.split(',').map(s => parseIdxColumn(s)).filter(Boolean) : [];
+    cols.forEach((c, i) => Utils.checkName(`인덱스 컬럼 #${i + 1}`, c.name, errs));
+    if (errs.length) { UI.showValidation(errs); return; }
+    UI.clearValidation();
     const colsExpr = cols.map(c => c.sort === 'DESC' ? `${c.name} DESC` : c.name).join(', ');
 
     let ddl;
@@ -138,8 +141,9 @@ const IndexTab = (() => {
     const d = readField('idx-drop', ['schema','tableName','indexName']);
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!d.schema) errs.push('스키마명 필수.');
-    if (!d.indexName) errs.push('인덱스명 필수.');
+    Utils.checkName('스키마명', d.schema, errs);
+    Utils.checkName('인덱스명', d.indexName, errs);
+    if (d.tableName) Utils.checkName('테이블명', Utils.ensurePrefix(d.tableName, 'TB'), errs);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 

--- a/js/sequence.js
+++ b/js/sequence.js
@@ -80,8 +80,10 @@ const SequenceTab = (() => {
     const d = readField('seq-c', ['schema','seqName','purposeCd','usedForTable','usedForColumn','incrementBy','startWith','minValue','maxValue','cacheSize','cycleYn','orderYn']);
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!d.schema) errs.push('스키마명 필수.');
-    if (!d.seqName) errs.push('시퀀스명 필수.');
+    Utils.checkName('스키마명', d.schema, errs);
+    Utils.checkName('시퀀스명', d.seqName ? buildSeqName(d.seqName) : '', errs);
+    Utils.checkName('주 사용 테이블', d.usedForTable, errs, false);
+    Utils.checkName('주 사용 컬럼', d.usedForColumn, errs, false);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 
@@ -124,7 +126,10 @@ const SequenceTab = (() => {
     const d = readField('seq-a', ['schema','seqName','purposeCd','usedForTable','usedForColumn','incrementBy','minValue','maxValue','cacheSize','cycleYn','orderYn']);
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!d.schema || !d.seqName) errs.push('스키마/시퀀스명 필수.');
+    Utils.checkName('스키마명', d.schema, errs);
+    Utils.checkName('시퀀스명', d.seqName ? buildSeqName(d.seqName) : '', errs);
+    Utils.checkName('주 사용 테이블', d.usedForTable, errs, false);
+    Utils.checkName('주 사용 컬럼', d.usedForColumn, errs, false);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 
@@ -170,7 +175,8 @@ const SequenceTab = (() => {
     const seqName = (document.getElementById('seq-d-seqName').value || '').trim();
     const errs = [];
     if (!reason) errs.push('상단 변경 사유 필수.');
-    if (!schema || !seqName) errs.push('스키마/시퀀스명 필수.');
+    Utils.checkName('스키마명', schema, errs);
+    Utils.checkName('시퀀스명', seqName ? buildSeqName(seqName) : '', errs);
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 

--- a/js/table.js
+++ b/js/table.js
@@ -180,9 +180,12 @@ const TableTab = (() => {
 
     const errors = [];
     if (!reason) errors.push('상단 "변경 사유"를 입력하세요.');
-    if (!meta.schema) errors.push('스키마명이 필요합니다.');
-    if (!meta.tableName) errors.push('테이블명이 필요합니다.');
+    Utils.checkName('스키마명', meta.schema, errors);
+    Utils.checkName('테이블명', meta.tableName ? Utils.ensurePrefix(meta.tableName, 'TB') : '', errors);
     if (cols.length === 0) errors.push('컬럼을 1개 이상 추가하세요.');
+    cols.forEach((c, i) => Utils.checkName(`${i + 1}번 컬럼명`, c.colName, errors));
+    Utils.checkName('테이블스페이스', meta.tablespace, errors, false);
+    if (meta.viewGenYn) Utils.checkName('뷰명', meta.viewName, errors, false);
     if (errors.length) { UI.showValidation(errors); return; }
     UI.clearValidation();
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -46,6 +46,16 @@ const Utils = {
     return null;
   },
 
+  /** 식별자 검증 → errors 배열에 누적. value가 빈 값이고 required=false면 통과. */
+  checkName(label, value, errors, required = true) {
+    if (!value) {
+      if (required) errors.push(`${label}: 값이 필요합니다.`);
+      return;
+    }
+    const err = Utils.validateName(String(value).toUpperCase());
+    if (err) errors.push(`${label}(${value}): ${err}`);
+  },
+
   /** 드롭다운 option 생성 */
   buildOptions(codeGroup, includeEmpty = true) {
     const arr = CODES[codeGroup] || [];


### PR DESCRIPTION
## 변경 내용
`Utils.validateName`이 정의돼 있으나 호출되지 않아, 식별자 입력란에 작은따옴표·세미콜론·공백·한글이 그대로 통과되던 보안 결함을 수정.

### 추가
- `Utils.checkName(label, value, errors, required=true)` 헬퍼 추가
  - uppercase 변환 후 `validateName`으로 검증, 결과를 errors 배열에 누적
  - required=false 시 빈 값은 통과 (옵션 필드용)

### 검증 적용 위치
| 파일 | 함수 | 검증 식별자 |
|---|---|---|
| table.js | generate() | schema, tableName(prefix적용 후), 각 colName, tablespace(opt), viewName(opt) |
| column.js | genAdd/genModify/genDrop | schema, tableName, colName |
| indexMgr.js | genCreate | schema, tableName, indexName(opt), tablespace(opt), 컬럼 목록 |
| indexMgr.js | genDrop | schema, indexName, tableName(opt) |
| sequence.js | genCreate/genAlter | schema, seqName, usedForTable(opt), usedForColumn(opt) |
| sequence.js | genDrop | schema, seqName |

### 재현 차단 확인
`MEMBER; DROP TABLE TB_META_TABLE--` 입력 시 `UI.showValidation`으로 차단됨을 sandbox에서 확인.

Closes #1

Closes #2