### PR TITLE
fix(#4): PK 컬럼은 NULLABLE_YN='N' 강제 (DDL과 메타 정합)

### DIFF
--- a/js/table.js
+++ b/js/table.js
@@ -194,7 +194,7 @@ const TableTab = (() => {
       const type = Utils.typeDDL(c.dataType, c.dataLength, c.dataPrecision, c.dataScale);
       let line = `    ${c.colName.toUpperCase().padEnd(30)} ${type.padEnd(18)}`;
       if (c.defaultValue) line += ` DEFAULT ${c.defaultValue}`;
-      line += c.nullableYn ? '' : ' NOT NULL';
+      line += (c.pkYn ? false : c.nullableYn) ? '' : ' NOT NULL';
       return line;
     }).join(',\n');
 
@@ -260,7 +260,7 @@ const TableTab = (() => {
     ${Utils.q(c.colName.toUpperCase())}, ${i + 1},
     ${Utils.q(c.logicalName)}, ${Utils.q(c.description)},
     ${Utils.q(c.dataType)}, ${Utils.num(c.dataLength)}, ${Utils.num(c.dataPrecision)}, ${Utils.num(c.dataScale)},
-    ${Utils.yn(c.nullableYn)}, ${Utils.q(c.defaultValue)},
+    ${Utils.yn(c.pkYn ? false : c.nullableYn)}, ${Utils.q(c.defaultValue)},
     ${Utils.yn(c.pkYn)}, ${Utils.yn(c.ukYn)}, ${Utils.yn(c.fkYn)},
     ${Utils.yn(c.piiYn)}, ${Utils.yn(c.pciYn)}, ${Utils.q(c.pciCategoryCd)}, 'LOW',
     ${Utils.yn(c.encryptionYn)}, NULL, ${Utils.yn(c.maskingYn)}, ${Utils.q(c.maskingRuleCd)},


### PR DESCRIPTION
## 변경
- DDL 컬럼 라인: PK 컬럼이면 사용자 입력과 무관하게 NOT NULL 명시 출력.
- TB_META_COLUMN INSERT: PK 컬럼이면 NULLABLE_YN='N' 강제.
- 두 위치 모두 동일 표현 `(c.pkYn ? false : c.nullableYn)`로 치환.

## 효과
사용자가 PK 컬럼의 NULL 허용 체크박스를 켠 채로 SQL을 생성해도 DB(NOT NULL by PK constraint)와 메타(NULLABLE_YN='N')가 일치 → §8.3 drift false-positive 차단.

Closes #4