### PR TITLE
fix(#18): typeDDL에 lengthSemantics 인자 추가 (foundation for CHAR/BYTE 시맨틱)

### DIFF
--- a/js/codes.js
+++ b/js/codes.js
@@ -121,4 +121,7 @@ const CODES = {
     'VARCHAR2', 'CHAR', 'NUMBER', 'DATE', 'TIMESTAMP',
     'CLOB', 'BLOB', 'RAW', 'FLOAT', 'BINARY_DOUBLE',
   ],
+
+  // 길이 시맨틱 (VARCHAR2/CHAR 전용; 미지정 시 NLS_LENGTH_SEMANTICS 따름)
+  LENGTH_SEMANTICS: ['BYTE', 'CHAR'],
 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -59,11 +59,17 @@ const Utils = {
     return html;
   },
 
-  /** Oracle 데이터타입 → 컬럼 DDL 일부 */
-  typeDDL(type, length, precision, scale) {
+  /** Oracle 데이터타입 → 컬럼 DDL 일부
+   *  @param {string} [lengthSemantics] 'BYTE'|'CHAR' (VARCHAR2/CHAR 전용, 미지정 시 Oracle 세션 기본값(NLS_LENGTH_SEMANTICS) 따름) */
+  typeDDL(type, length, precision, scale, lengthSemantics) {
     const t = (type || '').toUpperCase();
-    if (t === 'VARCHAR2' || t === 'CHAR' || t === 'RAW') {
-      return `${t}(${length || 1})`;
+    if (t === 'VARCHAR2' || t === 'CHAR') {
+      const sem = (lengthSemantics || '').toUpperCase();
+      const semSuffix = (sem === 'CHAR' || sem === 'BYTE') ? ` ${sem}` : '';
+      return `${t}(${length || 1}${semSuffix})`;
+    }
+    if (t === 'RAW') {
+      return `RAW(${length || 1})`;
     }
     if (t === 'NUMBER') {
       if (precision && scale !== null && scale !== undefined && scale !== '') {


### PR DESCRIPTION
## 변경 (foundation only)
- **js/utils.js** `typeDDL(type, length, precision, scale, lengthSemantics)`:
  - 5번째 인자 `lengthSemantics` ('BYTE' | 'CHAR') 추가.
  - VARCHAR2 / CHAR 타입에서 'CHAR' 또는 'BYTE' 명시 시 `VARCHAR2(20 CHAR)` 형태 출력.
  - 미지정 시 기존 동작 그대로 (`VARCHAR2(20)`) — Oracle 세션 NLS_LENGTH_SEMANTICS 따름.
  - RAW는 시맨틱 비대상이므로 분리 처리.
- **js/codes.js**: `LENGTH_SEMANTICS = ['BYTE','CHAR']` 코드 그룹 추가.

## 후속 (별도 이슈/PR)
- js/table.js의 컬럼 편집 row UI에 시맨틱 select 추가 + collectColumns에서 lengthSemantics 수집 → typeDDL 호출 시 전달.
- js/column.js의 add/modify 폼에 시맨틱 select 추가.
- TB_META_COLUMN에 LENGTH_SEMANTICS_CD 컬럼 추가 (메타 스키마 표준 보강).

본 PR은 위 후속 작업의 의존인 `typeDDL` 시그니처와 코드값만 우선 도입한다.

Closes #18