### PR TITLE
fix(#5): UK 체크 컬럼은 컬럼별 단일 UK 제약으로 분리

### DIFF
--- a/js/table.js
+++ b/js/table.js
@@ -203,7 +203,10 @@ const TableTab = (() => {
 
     let ddl = `CREATE TABLE ${schema}.${tbl} (\n${ddlCols}`;
     if (pkCols.length) ddl += `,\n    CONSTRAINT PK_${tbl.replace(/^TB_/, '')} PRIMARY KEY (${pkCols.join(', ')})`;
-    if (ukCols.length) ddl += `,\n    CONSTRAINT UK_${tbl.replace(/^TB_/, '')}_01 UNIQUE (${ukCols.join(', ')})`;
+    ukCols.forEach((uk, i) => {
+      const seq = String(i + 1).padStart(2, '0');
+      ddl += `,\n    CONSTRAINT UK_${tbl.replace(/^TB_/, '')}_${seq} UNIQUE (${uk})`;
+    });
     ddl += '\n)';
     if (meta.tablespace) ddl += `\nTABLESPACE ${meta.tablespace.toUpperCase()}`;
     ddl += ';\n';


### PR DESCRIPTION
## 변경
- js/table.js: `CREATE TABLE` 본문에서 UK 체크된 컬럼들을 단일 복합 `UK_X_01 UNIQUE (A,B)`로 묶지 않고, 컬럼별 `UK_X_01 UNIQUE(A)`, `UK_X_02 UNIQUE(B)` … 로 분리 생성. 시퀀스는 zero-padded 2자리.

## 의도
사용자가 컬럼 행마다 UK 체크하는 UI 패턴은 보통 컬럼별 단일 UK를 의도한다. 기존 동작(복합 UK)은 silent mismatch였다.

## 후속 (이슈 본문 옵션2)
복합 UK가 필요한 경우의 'UK 그룹 입력' UI는 별도 이슈로 분리 권장.

Closes #5