### PR TITLE
fix(#6): HARD DROP SQL 상단에 implicit commit 경고 블록 추가

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -277,7 +277,20 @@ const ColumnTab = (() => {
       out += Utils.section('컬럼 HIST INSERT (U, SOFT)') + hist + '\n\nCOMMIT;\n';
     } else {
       out += Utils.section(`컬럼 하드 삭제: ${schema}.${tbl}.${col}`);
-      out += `-- [주의] HARD 삭제: HIST를 먼저 남기고 원본을 DROP합니다.\n`;
+      out += `-- ═══════════════════════════════════════════════════════════════════
+-- [경고] HARD 삭제 — implicit commit 주의
+-- ───────────────────────────────────────────────────────────────────
+-- ALTER TABLE … DROP COLUMN 은 Oracle에서 DDL이며 직전·직후로
+-- implicit commit을 동반합니다. 본 SQL의 어느 단계가 실패해도 이미
+-- commit된 단계는 롤백되지 않습니다(SAVEPOINT 효과 없음).
+--
+-- 실패 발생 시 다음을 반드시 확인:
+--   1) HIST 적재 여부 (TB_META_*_HIST)
+--   2) 원본/메타 DELETE 여부
+--   3) Oracle 측 인덱스 자동 DROP 여부
+-- 부정합이 발견되면 수동 cleanup으로 일관성 회복하세요.
+-- ═══════════════════════════════════════════════════════════════════
+`;
 
       // 인덱스 정리 대상: 이 컬럼만으로 구성된(다른 컬럼이 없는) 인덱스
       // → ALTER TABLE DROP COLUMN 시 Oracle이 해당 인덱스를 자동 DROP하므로 메타도 동기화.

--- a/js/indexMgr.js
+++ b/js/indexMgr.js
@@ -159,7 +159,19 @@ const IndexTab = (() => {
     const hist = Utils.snapshotHist({ kind:'INDEX', op:'D', reason, empId:emp, whereClause: whereIdx });
 
     let out = Utils.section(`인덱스 삭제: ${schema}.${idxName}`);
-    out += `-- [주의] HARD 삭제: HIST 먼저, 원본 DROP을 나중에.\n`;
+    out += `-- ═══════════════════════════════════════════════════════════════════
+-- [경고] DROP INDEX — implicit commit 주의
+-- ───────────────────────────────────────────────────────────────────
+-- DROP INDEX 는 DDL이며 implicit commit을 동반합니다. 본 SQL의 어느
+-- 단계가 실패해도 이미 commit된 단계는 롤백되지 않습니다.
+--
+-- 실패 발생 시 다음을 반드시 확인:
+--   1) HIST 적재 여부 (TB_META_INDEX_HIST)
+--   2) 메타 DELETE 여부 (TB_META_INDEX_COLUMN, TB_META_INDEX)
+--   3) Oracle 측 실제 인덱스 잔존 여부
+-- 부정합이 발견되면 수동 cleanup으로 일관성 회복하세요.
+-- ═══════════════════════════════════════════════════════════════════
+`;
     out += Utils.section('1. 인덱스 HIST INSERT (D, 삭제 전 스냅샷)') + hist + '\n';
     out += Utils.section('2. 인덱스-컬럼 매핑 DELETE') + `DELETE FROM TB_META_INDEX_COLUMN
  WHERE INDEX_ID IN (SELECT INDEX_ID FROM TB_META_INDEX WHERE ${whereIdx});\n`;

--- a/js/sequence.js
+++ b/js/sequence.js
@@ -185,7 +185,19 @@ const SequenceTab = (() => {
     const hist = Utils.snapshotHist({ kind:'SEQUENCE', op:'D', reason, empId:emp, whereClause: whereSeq });
 
     let out = Utils.section(`시퀀스 삭제: ${schema}.${seq}`);
-    out += `-- [주의] HARD 삭제: HIST 먼저, 원본 DROP을 나중에.\n`;
+    out += `-- ═══════════════════════════════════════════════════════════════════
+-- [경고] DROP SEQUENCE — implicit commit 주의
+-- ───────────────────────────────────────────────────────────────────
+-- DROP SEQUENCE 는 DDL이며 implicit commit을 동반합니다. 본 SQL의 어느
+-- 단계가 실패해도 이미 commit된 단계는 롤백되지 않습니다.
+--
+-- 실패 발생 시 다음을 반드시 확인:
+--   1) HIST 적재 여부 (TB_META_SEQUENCE_HIST)
+--   2) 메타 DELETE 여부 (TB_META_SEQUENCE)
+--   3) Oracle 측 실제 시퀀스 잔존 여부
+-- 부정합이 발견되면 수동 cleanup으로 일관성 회복하세요.
+-- ═══════════════════════════════════════════════════════════════════
+`;
     out += Utils.section('1. 시퀀스 HIST INSERT (D, 삭제 전 스냅샷)') + hist + '\n';
     out += Utils.section('2. 메타 DELETE') + `DELETE FROM TB_META_SEQUENCE WHERE ${whereSeq};\n`;
     out += Utils.section('3. 물리 DROP') + `DROP SEQUENCE ${schema}.${seq};\n\nCOMMIT;\n`;


### PR DESCRIPTION
## 변경
js/column.js / js/indexMgr.js / js/sequence.js 의 HARD-drop 분기 출력 상단에 강조 경고 블록 추가.
- DDL(ALTER TABLE DROP COLUMN, DROP INDEX, DROP SEQUENCE)은 implicit commit이며 SAVEPOINT 효과 없음을 명시.
- 실패 시 검증 항목(HIST 적재 / 원본·메타 DELETE / Oracle 측 잔존 여부) 체크리스트 제공.
- 표준 §2는 PL/SQL 금지이므로 트랜잭션 보호 불가 → 운영자가 수동 cleanup하도록 가이드.

기존 1-line `[주의]` 코멘트는 신규 블록으로 흡수.

## 미진
장기 해결책(SAVEPOINT/PL/SQL block 권장)은 표준 §2 변경 필요 — 별도 표준 보강 이슈로 분리.

Closes #6