### PR TITLE
fix(#9): 컬럼 MODIFY에 텍스트/select touched-tracking 확장 — 빈 값으로 NULL 변경 가능

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -11,6 +11,28 @@ const ColumnTab = (() => {
     UI.initSectionToggles(document.getElementById('col-tab'));
   }
 
+  /**
+   * MODIFY 입력 요소의 사용자 명시적 수정 여부 추적.
+   * - 사용자가 한 번이라도 값을 만지면 dataset.touched = '1'.
+   * - genModify() SET 절에서 touched 인 경우에만 컬럼을 포함, touched && empty 시 NULL 명시.
+   */
+  function bindModifyTouchTracking() {
+    const root = document.getElementById('col-mod');
+    if (!root) return;
+    root.querySelectorAll('input, select, textarea').forEach(el => {
+      // 다중 호출 시 중복 부착 방지
+      if (el.dataset.touchBound === '1') return;
+      el.dataset.touchBound = '1';
+      const evt = (el.tagName === 'SELECT' || el.type === 'checkbox') ? 'change' : 'input';
+      el.addEventListener(evt, () => { el.dataset.touched = '1'; }, { once: true });
+    });
+  }
+
+  function isTouched(prefix, field) {
+    const el = document.getElementById(`${prefix}-${field}`);
+    return !!(el && el.dataset.touched === '1');
+  }
+
   function tblPickerFields(prefix) {
     return [
       { label:'스키마명', req:true, name:'schema', id:`${prefix}-schema` },
@@ -66,6 +88,7 @@ const ColumnTab = (() => {
     UI.renderFields(wrap, colFields('col-mod', false));
     const allWithId = document.querySelectorAll('#col-mod [id="col-mod-colName"]');
     if (allWithId.length > 1) allWithId[1].closest('.field').remove();
+    bindModifyTouchTracking();
   }
 
   function renderDrop() {
@@ -204,25 +227,30 @@ const ColumnTab = (() => {
     ddl += ');\n';
     if (c.logicalName) ddl += `COMMENT ON COLUMN ${schema}.${tbl}.${col} IS ${Utils.q(c.logicalName)};\n`;
 
+    // touched 인 경우에만 SET 포함. Utils.q('') === 'NULL' 이므로
+    // touched && empty 시 'COL = NULL' 이 자연스럽게 출력되어 빈 값으로 비울 수 있음.
+    const setIfTouched = (col, field, valExpr) =>
+      isTouched('col-mod', field) ? `${col} = ${valExpr}` : null;
+
     const sets = [
-      c.logicalName ? `LOGICAL_NAME = ${Utils.q(c.logicalName)}` : null,
-      c.description ? `DESCRIPTION = ${Utils.q(c.description)}` : null,
-      c.dataType    ? `DATA_TYPE = ${Utils.q(c.dataType)}` : null,
-      `DATA_LENGTH = ${Utils.num(c.dataLength)}`,
-      `DATA_PRECISION = ${Utils.num(c.dataPrecision)}`,
-      `DATA_SCALE = ${Utils.num(c.dataScale)}`,
+      setIfTouched('LOGICAL_NAME',        'logicalName',       Utils.q(c.logicalName)),
+      setIfTouched('DESCRIPTION',         'description',       Utils.q(c.description)),
+      setIfTouched('DATA_TYPE',           'dataType',          Utils.q(c.dataType)),
+      setIfTouched('DATA_LENGTH',         'dataLength',        Utils.num(c.dataLength)),
+      setIfTouched('DATA_PRECISION',      'dataPrecision',     Utils.num(c.dataPrecision)),
+      setIfTouched('DATA_SCALE',          'dataScale',         Utils.num(c.dataScale)),
       `NULLABLE_YN = ${Utils.yn(c.nullableYn)}`,
-      `DEFAULT_VALUE = ${Utils.q(c.defaultValue)}`,
+      setIfTouched('DEFAULT_VALUE',       'defaultValue',      Utils.q(c.defaultValue)),
       `PII_YN = ${Utils.yn(c.piiYn)}`,
       `PCI_YN = ${Utils.yn(c.pciYn)}`,
-      `PCI_CATEGORY_CD = ${Utils.q(c.pciCategoryCd)}`,
+      setIfTouched('PCI_CATEGORY_CD',     'pciCategoryCd',     Utils.q(c.pciCategoryCd)),
       `SENSITIVITY_CD = ${Utils.q(c.sensitivityCd || 'LOW')}`,
       `ENCRYPTION_YN = ${Utils.yn(c.encryptionYn)}`,
-      `ENCRYPTION_ALG = ${Utils.q(c.encryptionAlg)}`,
+      setIfTouched('ENCRYPTION_ALG',      'encryptionAlg',     Utils.q(c.encryptionAlg)),
       `MASKING_YN = ${Utils.yn(c.maskingYn)}`,
-      `MASKING_RULE_CD = ${Utils.q(c.maskingRuleCd)}`,
-      `RETENTION_PERIOD_CD = ${Utils.q(c.retentionPeriodCd)}`,
-      `TOS_CD = ${Utils.q(c.tosCd)}`,
+      setIfTouched('MASKING_RULE_CD',     'maskingRuleCd',     Utils.q(c.maskingRuleCd)),
+      setIfTouched('RETENTION_PERIOD_CD', 'retentionPeriodCd', Utils.q(c.retentionPeriodCd)),
+      setIfTouched('TOS_CD',              'tosCd',             Utils.q(c.tosCd)),
       Utils.auditCols(emp).update,
     ].filter(Boolean).join(',\n       ');
 


### PR DESCRIPTION
## 변경
- `bindModifyTouchTracking()` 신규 추가 — `#col-mod` 하위 모든 `input/select/textarea`에 once-listener 부착, 사용자가 명시적으로 수정하면 `dataset.touched = '1'`.
- `isTouched(prefix, field)` 헬퍼 신규 추가.
- `renderModify()` 끝에서 `bindModifyTouchTracking()` 호출 — `init()` / `clear()` 양쪽 재렌더 모두 커버.
- `genModify()` SET 빌드를 truthy 체크 → touched 체크로 전환:
  - 텍스트/select: `logicalName`, `description`, `pciCategoryCd`, `encryptionAlg`, `maskingRuleCd`, `retentionPeriodCd`, `tosCd`.
  - 추가 정합성 차원에서 `dataType` / `dataLength` / `dataPrecision` / `dataScale` / `defaultValue` 도 동일하게 touched 게이트 (이전엔 무조건 SET 또는 truthy SET).
- `touched && empty` 시 `Utils.q('') === 'NULL'` 동작에 의해 `COL = NULL` 로 자연 출력.

## 효과
사용자가 한 번 채운 텍스트/select 값을 빈 값으로 수정하면 메타 UPDATE에 `LOGICAL_NAME = NULL` / `PCI_CATEGORY_CD = NULL` 등이 정확히 출력됨 (이전엔 SET에서 빠져 변경 불가).

## 미진 (후속 이슈)
- COMMENT 를 빈 값으로 비우는 DDL(`COMMENT ON COLUMN … IS NULL`)은 본 PR 범위 밖. `renderModify()`/`genModify()` 의 DDL 분기 (`if (c.logicalName) ddl += COMMENT …`)는 그대로 유지.
- 체크박스 SET (`NULLABLE_YN` / `PII_YN` / `PCI_YN` / `ENCRYPTION_YN` / `MASKING_YN`) 의 touched-pattern 전환은 ID 컨벤션 정리 후 별도 이슈 — 현재 `colFields` 가 `pciYn → col-mod-pci`, `encryptionYn → col-mod-enc`, `maskingYn → col-mod-mask` 로 단축 ID를 쓰고 `piiYn` 은 렌더되지 않아, ID 컨벤션이 `{prefix}-{field}` 와 어긋남. 별도 정리 PR 필요.

## 검증
- `node --check js/column.js` 통과.

Closes #9