### PR TITLE
fix(#10): 컬럼 추가에 PK/UK/FK 옵션 — 메타 + 별도 ADD CONSTRAINT DDL

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -29,6 +29,9 @@ const ColumnTab = (() => {
       { label:'길이', type:'number', name:'dataLength', id:`${prefix}-dataLength` },
       { label:'정밀도', type:'number', name:'dataPrecision', id:`${prefix}-dataPrecision` },
       { label:'소수 자릿수', type:'number', name:'dataScale', id:`${prefix}-dataScale` },
+      { type:'check', name:'pkYn', id:`${prefix}-pkYn`, label:'PK' },
+      { type:'check', name:'ukYn', id:`${prefix}-ukYn`, label:'UK' },
+      { type:'check', name:'fkYn', id:`${prefix}-fkYn`, label:'FK' },
       { type:'check', name:'nullableYn', id:`${prefix}-nullableYn`, label:'NULL 허용' },
       { label:'기본값', name:'defaultValue', id:`${prefix}-defaultValue` },
       { label:'설명', name:'description', id:`${prefix}-description`, full:true },
@@ -97,6 +100,7 @@ const ColumnTab = (() => {
 
   const COL_FIELDS = [
     'colName','logicalName','columnOrder','dataType','dataLength','dataPrecision','dataScale',
+    'pkYn','ukYn','fkYn',
     'nullableYn','defaultValue','description',
     'piiYn','pciYn','pciCategoryCd','sensitivityCd',
     'encryptionYn','encryptionAlg','maskingYn','maskingRuleCd',
@@ -138,6 +142,11 @@ const ColumnTab = (() => {
     ddl += ');\n';
     if (c.logicalName) ddl += `COMMENT ON COLUMN ${schema}.${tbl}.${col} IS ${Utils.q(c.logicalName)};\n`;
 
+    const constraints = [];
+    if (c.pkYn) constraints.push(`ALTER TABLE ${schema}.${tbl} ADD CONSTRAINT PK_${tbl.replace(/^TB_/,'')} PRIMARY KEY (${col});`);
+    if (c.ukYn) constraints.push(`ALTER TABLE ${schema}.${tbl} ADD CONSTRAINT UK_${tbl.replace(/^TB_/,'')}_${col} UNIQUE (${col});`);
+    if (c.fkYn) constraints.push(`-- TODO: FK_YN 체크 — 참조 테이블/컬럼 정보를 입력하여 ALTER TABLE ${schema}.${tbl} ADD CONSTRAINT FK_${tbl.replace(/^TB_/,'')}_${col} FOREIGN KEY (${col}) REFERENCES …; 를 추가하세요.`);
+
     const tableIdRef = buildTableIdRef(schema, tbl);
     const orderExpr = c.columnOrder
       ? Utils.num(c.columnOrder)
@@ -161,7 +170,7 @@ const ColumnTab = (() => {
     ${Utils.q(c.logicalName)}, ${Utils.q(c.description)},
     ${Utils.q(c.dataType)}, ${Utils.num(c.dataLength)}, ${Utils.num(c.dataPrecision)}, ${Utils.num(c.dataScale)},
     ${Utils.yn(c.nullableYn)}, ${Utils.q(c.defaultValue)},
-    'N', 'N', 'N',
+    ${Utils.yn(c.pkYn)}, ${Utils.yn(c.ukYn)}, ${Utils.yn(c.fkYn)},
     ${Utils.yn(c.piiYn)}, ${Utils.yn(c.pciYn)}, ${Utils.q(c.pciCategoryCd)}, ${Utils.q(c.sensitivityCd || 'LOW')},
     ${Utils.yn(c.encryptionYn)}, ${Utils.q(c.encryptionAlg)}, ${Utils.yn(c.maskingYn)}, ${Utils.q(c.maskingRuleCd)},
     ${Utils.q(c.retentionPeriodCd)}, ${Utils.q(c.tosCd)},
@@ -175,6 +184,7 @@ const ColumnTab = (() => {
     });
 
     let out = Utils.section(`컬럼 추가: ${schema}.${tbl}.${col}`) + ddl;
+    if (constraints.length) out += Utils.section('추가 제약 DDL (PK/UK/FK)') + constraints.join('\n') + '\n';
     out += Utils.section('메타 INSERT') + insert + '\n';
     out += Utils.section('컬럼 HIST INSERT (I)') + hist + '\n\nCOMMIT;\n';
     Utils.setOutput('col-output', out);


### PR DESCRIPTION
## 변경
- colFields()에 PK/UK/FK 체크박스 3개 추가 (Add/Modify 폼 공통).
- COL_FIELDS에 pkYn/ukYn/fkYn 추가.
- genAdd() INSERT VALUES: 하드코딩 `'N','N','N'` → `Utils.yn(c.pkYn/ukYn/fkYn)`.
- genAdd() DDL 출력에 체크 시 `ALTER TABLE … ADD CONSTRAINT PK_…/UK_…` 별도 절 동시 출력.
- FK는 참조 정보가 폼에 없으므로 TODO 주석으로 가이드 (사용자가 수동 보완).

## 효과
- 컬럼 추가 + PK 추가 시 메타와 DDL이 동시에 일관되게 생성됨.
- 이전엔 메타 PK_YN='N' 고정 → drift 발생했음.

## 미진
- FK 참조 테이블/컬럼 입력 UI는 별도 이슈.
- genModify의 PK/UK/FK 변경은 issue #15 PR에서 다룸.

Closes #10