### PR TITLE
fix(#11): DEFAULT_VALUE 입력란에 SQL 표현식 가이드 추가

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -30,7 +30,7 @@ const ColumnTab = (() => {
       { label:'정밀도', type:'number', name:'dataPrecision', id:`${prefix}-dataPrecision` },
       { label:'소수 자릿수', type:'number', name:'dataScale', id:`${prefix}-dataScale` },
       { type:'check', name:'nullableYn', id:`${prefix}-nullableYn`, label:'NULL 허용' },
-      { label:'기본값', name:'defaultValue', id:`${prefix}-defaultValue` },
+      { label:'기본값', name:'defaultValue', id:`${prefix}-defaultValue`, placeholder:`'N' / 0 / SYSDATE`, hint:"(SQL 표현식 그대로 — 문자열은 작은따옴표 포함)" },
       { label:'설명', name:'description', id:`${prefix}-description`, full:true },
       { type:'check', name:'pciYn', id:`${prefix}-pci`, label:'개인신용정보', chip:'pci' },
       { label:'PCI 분류', type:'select', name:'pciCategoryCd', id:`${prefix}-pciCategoryCd`, code:'PCI_CATEGORY' },

--- a/js/table.js
+++ b/js/table.js
@@ -125,7 +125,7 @@ const TableTab = (() => {
       <td class="flag-cell"><input type="checkbox" name="encryptionYn"></td>
       <td class="flag-cell"><input type="checkbox" name="maskingYn"></td>
       <td><select name="maskingRuleCd">${Utils.buildOptions('MASKING_RULE', true)}</select></td>
-      <td><input type="text" name="defaultValue"></td>
+      <td><input type="text" name="defaultValue" placeholder="'N' / 0 / SYSDATE" title="Oracle DDL DEFAULT 절에 들어갈 SQL 표현식 그대로. 문자열은 작은따옴표 포함, 숫자는 그대로, 함수는 SYSDATE/SYSTIMESTAMP 등."></td>
       <td><input type="text" name="description"></td>
       <td><button type="button" class="row-del" title="삭제">×</button></td>
     `;


### PR DESCRIPTION
## 변경
- js/table.js — 컬럼 row의 defaultValue input에 `placeholder='N' / 0 / SYSDATE` 와 `title` 툴팁(SQL 표현식 그대로 입력 안내) 추가.
- js/column.js — Add/Modify 폼 colFields의 defaultValue 필드에 동일 placeholder + hint 추가.

## 효과
사용자가 `N` (따옴표 없음) 입력 시 ORA-00984 발생 같은 silent error를 사전에 안내.

## 미진
1. (선택) 빠른 입력 버튼(SYSDATE/0/'Y'/'N')은 별도 UX 이슈.
2. `DB_메타정보_관리체계_표준설계.md` §4.2 DEFAULT_VALUE 정의 보강은 별도 doc 이슈.

Closes #11