### PR TITLE
fix(#15): 컬럼 MODIFY에 PK_YN/UK_YN/FK_YN 변경 경로 추가

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -259,6 +259,9 @@ const ColumnTab = (() => {
       setIfTouched('DATA_SCALE',          'dataScale',         Utils.num(c.dataScale)),
       `NULLABLE_YN = ${Utils.yn(c.nullableYn)}`,
       setIfTouched('DEFAULT_VALUE',       'defaultValue',      Utils.q(c.defaultValue)),
+      setIfTouched('PK_YN',               'pkYn',              Utils.yn(c.pkYn)),
+      setIfTouched('UK_YN',               'ukYn',              Utils.yn(c.ukYn)),
+      setIfTouched('FK_YN',               'fkYn',              Utils.yn(c.fkYn)),
       `PII_YN = ${Utils.yn(c.piiYn)}`,
       `PCI_YN = ${Utils.yn(c.pciYn)}`,
       setIfTouched('PCI_CATEGORY_CD',     'pciCategoryCd',     Utils.q(c.pciCategoryCd)),
@@ -283,7 +286,16 @@ const ColumnTab = (() => {
       whereClause: `TABLE_ID = ${tableIdRef} AND COLUMN_NAME = ${Utils.q(col)}`,
     });
 
+    const tblBase = tbl.replace(/^TB_/, '');
+    const constraints = [];
+    if (c.pkYn) constraints.push(`ALTER TABLE ${schema}.${tbl} ADD CONSTRAINT PK_${tblBase} PRIMARY KEY (${col});`);
+    else        constraints.push(`-- TODO: PK 해제 시 DROP CONSTRAINT 수동 보완 — 예) ALTER TABLE ${schema}.${tbl} DROP CONSTRAINT PK_${tblBase};`);
+    if (c.ukYn) constraints.push(`ALTER TABLE ${schema}.${tbl} ADD CONSTRAINT UK_${tblBase}_${col} UNIQUE (${col});`);
+    else        constraints.push(`-- TODO: UK 해제 시 DROP CONSTRAINT 수동 보완 — 예) ALTER TABLE ${schema}.${tbl} DROP CONSTRAINT UK_${tblBase}_${col};`);
+    constraints.push(`-- TODO: FK 변경 — ON이면 ADD CONSTRAINT FK_<NAME> FOREIGN KEY (${col}) REFERENCES <REF_TBL>(<REF_COL>); OFF면 DROP CONSTRAINT FK_<NAME>; (현재 ${c.fkYn ? 'ON' : 'OFF'} 의도)`);
+
     let out = Utils.section(`컬럼 변경: ${schema}.${tbl}.${col}`) + ddl;
+    out += Utils.section('제약조건 변경 (PK/UK/FK)') + constraints.join('\n') + '\n';
     out += Utils.section('메타 UPDATE') + update + '\n';
     out += Utils.section('컬럼 HIST INSERT (U, 변경 후 스냅샷)') + hist + '\n\nCOMMIT;\n';
     Utils.setOutput('col-output', out);


### PR DESCRIPTION
## 변경
- `colFields()`에 PK/UK/FK 체크박스 3개 추가 (Add/Modify 폼 공통, 이슈 #10 PR #28과 동일 변경 — 머지 충돌 없음 또는 redundant 제거).
- `COL_FIELDS`에 pkYn/ukYn/fkYn 추가.
- `genModify()` SET 절에 PK_YN/UK_YN/FK_YN 추가 — 운영 중 PK 추가/제거, FK 추가/제거 시 메타 동기화 가능.
- `genModify()` DDL 출력에 별도 '제약조건 변경 (PK/UK/FK)' 섹션 추가:
  - 체크 ON → `ALTER TABLE … ADD CONSTRAINT PK_<TBL>/UK_<TBL>_<COL>` 동시 출력.
  - 체크 OFF → DROP CONSTRAINT TODO 주석 (수동 보완 가이드).
  - FK는 참조 정보 부재로 ADD/DROP 모두 TODO 주석.

## 미진
- 본 PR은 origin/main(556624e) 기준이라 touch-tracking 인프라가 없음 → SET 절은 `PII_YN`/`PCI_YN` 등 기존 필드와 동일하게 무조건 기록. `DROP CONSTRAINT`는 자동 emit 시 사용자가 건드리지 않은 제약을 잘못 끊을 위험이 있어 TODO 주석으로 가드.
- 제약 이름 추정 휴리스틱(`PK_<TBL>`, `UK_<TBL>_<COL>`)은 명명 규칙 가정. 실제 이름과 다르면 사용자가 SQL 수정 필요.
- FK 참조 테이블/컬럼 입력 UI는 별도 이슈.

Closes #15