### PR TITLE
fix(#16): 컬럼 MODIFY에 STATUS_CD 변경 경로 추가

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -66,6 +66,7 @@ const ColumnTab = (() => {
       { label:'마스킹 규칙', type:'select', name:'maskingRuleCd', id:`${prefix}-maskingRuleCd`, code:'MASKING_RULE' },
       { label:'보관주기(예외)', type:'select', name:'retentionPeriodCd', id:`${prefix}-retentionPeriodCd`, code:'RETENTION_PERIOD' },
       { label:'이용약관(예외)', name:'tosCd', id:`${prefix}-tosCd` },
+      { label:'상태', type:'select', name:'statusCd', id:`${prefix}-statusCd`, code:'STATUS' },
     );
     return arr;
   }
@@ -127,7 +128,7 @@ const ColumnTab = (() => {
     'nullableYn','defaultValue','description',
     'piiYn','pciYn','pciCategoryCd','sensitivityCd',
     'encryptionYn','encryptionAlg','maskingYn','maskingRuleCd',
-    'retentionPeriodCd','tosCd',
+    'retentionPeriodCd','tosCd','statusCd',
   ];
 
   function generate() {
@@ -272,6 +273,7 @@ const ColumnTab = (() => {
       setIfTouched('MASKING_RULE_CD',     'maskingRuleCd',     Utils.q(c.maskingRuleCd)),
       setIfTouched('RETENTION_PERIOD_CD', 'retentionPeriodCd', Utils.q(c.retentionPeriodCd)),
       setIfTouched('TOS_CD',              'tosCd',             Utils.q(c.tosCd)),
+      c.statusCd ? `STATUS_CD = ${Utils.q(c.statusCd)}` : null,
       Utils.auditCols(emp).update,
     ].filter(Boolean).join(',\n       ');
 


### PR DESCRIPTION
## 변경
- js/codes.js: `STATUS` 코드 그룹은 이미 존재(line 41-45, `{value,name}` 형식)하여 변경 없음.
- js/column.js:
  - colFields()에 statusCd select 추가 (code:'STATUS', includeEmpty 기본 true).
  - COL_FIELDS에 'statusCd' 추가.
  - genModify() SET 절에 `STATUS_CD` 추가 — non-empty 가드(`c.statusCd ? ... : null`)로 빈 값일 때 SET 제외.

## 효과
- SOFT 삭제(STATUS='DEPRECATED')된 컬럼을 ACTIVE로 복귀 가능.
- PLANNED ↔ ACTIVE 전환 가능.
- 변경 시 HIST 'U' 적재는 기존 genModify 흐름이 자동 처리.

## 설계 메모
- main에는 `isTouched`/`bindModifyTouchTracking` 인프라가 없음. genModify는 항상 모든 SET 절을 출력하는 구조이며, 빈 값 가드(`c.X ? ... : null`) 패턴이 기존 LOGICAL_NAME/DESCRIPTION/DATA_TYPE에서 이미 사용 중이라 동일 패턴을 따름.
- includeEmpty:true(기본)이라 사용자가 상태를 선택하지 않으면 `c.statusCd === ''` → SET 절 제외, 의도치 않은 STATUS_CD 변경 방지.

## 미진
- genAdd 시점의 STATUS는 여전히 'ACTIVE' 하드코딩 — PLANNED 상태 신규 컬럼은 MODIFY로 한 번 더 변경해야 가능. 별도 이슈 권장.

Closes #16