### PR TITLE
fix(#14): 테이블 삭제 서브탭 추가 (SOFT/HARD per 표준 §6.8)

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
     </div>
 
     <div class="nav-section">작업</div>
-    <button class="nav-btn active" data-target="tbl-tab" title="테이블 신규 생성 (Alt+1)">
+    <button class="nav-btn active" data-target="tbl-tab" title="테이블 생성·삭제 (Alt+1)">
       <span class="nav-idx">01</span>
-      <span>테이블 신규 생성</span>
+      <span>테이블 생성·삭제</span>
     </button>
     <button class="nav-btn" data-target="col-tab" title="컬럼 추가·변경·삭제 (Alt+2)">
       <span class="nav-idx">02</span>
@@ -56,8 +56,8 @@
 
     <!-- Top bar: title + reason + actions -->
     <div class="topbar">
-      <h2 id="current-title">테이블 신규 생성</h2>
-      <span class="subtitle" id="current-subtitle">CREATE TABLE · META INSERT · HIST</span>
+      <h2 id="current-title">테이블 생성·삭제</h2>
+      <span class="subtitle" id="current-subtitle">CREATE/DROP TABLE · META DML · HIST</span>
 
       <div class="reason-bar" id="reason-bar">
         <label for="change-reason">변경 사유 <span style="color:var(--danger)">*</span></label>
@@ -98,48 +98,59 @@
 
           <!-- ═════ TAB 1: TABLE ═════ -->
           <section class="tab-panel active" id="tbl-tab">
-            <form id="tbl-meta-form" onsubmit="return false">
+            <div class="subtabs">
+              <button class="subtab-btn active" data-target="tbl-create"><span class="op-badge">CREATE</span>신규 생성</button>
+              <button class="subtab-btn" data-target="tbl-delete" data-op="DROP"><span class="op-badge">DROP</span>삭제</button>
+            </div>
 
-              <div class="section" data-section>
-                <div class="section-head" data-toggle>
-                  <div class="section-title"><span class="step">1</span>기본 정보</div>
-                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-                </div>
-                <div class="section-body" id="tbl-sec-basic"></div>
-              </div>
+            <div class="subtab-panel active" id="tbl-create">
+              <form id="tbl-meta-form" onsubmit="return false">
 
-              <div class="section" data-section>
-                <div class="section-head" data-toggle>
-                  <div class="section-title"><span class="step">2</span>소유·보안·격리</div>
-                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                <div class="section" data-section>
+                  <div class="section-head" data-toggle>
+                    <div class="section-title"><span class="step">1</span>기본 정보</div>
+                    <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                  </div>
+                  <div class="section-body" id="tbl-sec-basic"></div>
                 </div>
-                <div class="section-body" id="tbl-sec-owner"></div>
-              </div>
 
-              <div class="section" data-section>
-                <div class="section-head" data-toggle>
-                  <div class="section-title"><span class="step">3</span>보관·약관</div>
-                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                <div class="section" data-section>
+                  <div class="section-head" data-toggle>
+                    <div class="section-title"><span class="step">2</span>소유·보안·격리</div>
+                    <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                  </div>
+                  <div class="section-body" id="tbl-sec-owner"></div>
                 </div>
-                <div class="section-body" id="tbl-sec-retention"></div>
-              </div>
 
-              <div class="section" data-section>
-                <div class="section-head" data-toggle>
-                  <div class="section-title"><span class="step">4</span>뷰·테이블스페이스·비고</div>
-                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                <div class="section" data-section>
+                  <div class="section-head" data-toggle>
+                    <div class="section-title"><span class="step">3</span>보관·약관</div>
+                    <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                  </div>
+                  <div class="section-body" id="tbl-sec-retention"></div>
                 </div>
-                <div class="section-body" id="tbl-sec-view"></div>
-              </div>
 
-              <div class="section" data-section>
-                <div class="section-head" data-toggle>
-                  <div class="section-title"><span class="step">5</span>컬럼 정의 <span class="hint" id="tbl-col-count">· 0개</span></div>
-                  <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                <div class="section" data-section>
+                  <div class="section-head" data-toggle>
+                    <div class="section-title"><span class="step">4</span>뷰·테이블스페이스·비고</div>
+                    <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                  </div>
+                  <div class="section-body" id="tbl-sec-view"></div>
                 </div>
-                <div class="section-body" id="tbl-col-body"></div>
-              </div>
-            </form>
+
+                <div class="section" data-section>
+                  <div class="section-head" data-toggle>
+                    <div class="section-title"><span class="step">5</span>컬럼 정의 <span class="hint" id="tbl-col-count">· 0개</span></div>
+                    <svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+                  </div>
+                  <div class="section-body" id="tbl-col-body"></div>
+                </div>
+              </form>
+            </div>
+
+            <div class="subtab-panel" id="tbl-delete">
+              <div class="section"><div class="section-head" data-toggle><div class="section-title">테이블 삭제</div><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg></div><div class="section-body" id="tbl-delete-body"></div></div>
+            </div>
           </section>
 
           <!-- ═════ TAB 2: COLUMN ═════ -->
@@ -310,12 +321,12 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 <script src="js/ui.js?v=7"></script>
 <script src="js/sqlview.js?v=6"></script>
 <!-- Tab modules -->
-<script src="js/table.js?v=16"></script>
+<script src="js/table.js?v=17"></script>
 <script src="js/column.js?v=1"></script>
 <script src="js/indexMgr.js?v=1"></script>
 <script src="js/sequence.js?v=1"></script>
 <!-- App bootstrap (must load last) -->
-<script src="js/app.js?v=1"></script>
+<script src="js/app.js?v=2"></script>
 
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,7 @@ const App = (() => {
   let currentTab = 'tbl-tab';
 
   const TAB_META = {
-    'tbl-tab': { title:'테이블 신규 생성',        sub:'CREATE TABLE · META INSERT · HIST',        mod:TableTab },
+    'tbl-tab': { title:'테이블 생성·삭제',         sub:'CREATE/DROP TABLE · META DML · HIST',       mod:TableTab },
     'col-tab': { title:'컬럼 추가·변경·삭제',     sub:'ALTER · META DML · HIST',                   mod:ColumnTab },
     'idx-tab': { title:'인덱스 생성·삭제',        sub:'CREATE/DROP INDEX · META DML · HIST',       mod:IndexTab },
     'seq-tab': { title:'시퀀스 생성·변경·삭제',   sub:'CREATE/ALTER/DROP SEQUENCE · META DML · HIST', mod:SequenceTab },

--- a/js/table.js
+++ b/js/table.js
@@ -11,6 +11,7 @@ const TableTab = (() => {
     renderRetention();
     renderView();
     renderColumnEditor();
+    renderDelete();
     UI.initSectionToggles(document.getElementById('tbl-tab'));
     addColumnRow();
     updateColCount();
@@ -102,6 +103,22 @@ const TableTab = (() => {
     });
   }
 
+  function renderDelete() {
+    document.getElementById('tbl-delete-body').innerHTML = `
+      <div class="info">표준 §6.8 — HARD 삭제는 자식(INDEX_COLUMN → INDEX → COLUMN) → 부모(TABLE) 순서로 HIST 적재 후 DELETE.</div>
+      <div class="grid">
+        <div class="field"><label>스키마명 <span class="req">*</span></label><input type="text" id="tbl-d-schema"></div>
+        <div class="field"><label>테이블명 <span class="req">*</span></label><input type="text" id="tbl-d-tableName" placeholder="TB_MEMBER"></div>
+        <div class="field full"><label>삭제 처리 방식 <span class="req">*</span></label>
+          <select id="tbl-d-mode">
+            <option value="SOFT">SOFT — STATUS_CD='DEPRECATED' (권장)</option>
+            <option value="HARD">HARD — TB_META_TABLE 및 자식 메타 모두 DELETE + DROP TABLE</option>
+          </select>
+        </div>
+      </div>
+    `;
+  }
+
   function addColumnRow(preset = {}) {
     colCounter += 1;
     const tbody = document.querySelector('#tbl-col-table tbody');
@@ -173,6 +190,13 @@ const TableTab = (() => {
   }
 
   function generate() {
+    const activeEl = document.querySelector('#tbl-tab .subtab-panel.active');
+    const active = activeEl ? activeEl.id : 'tbl-create';
+    if (active === 'tbl-delete') return genDelete();
+    return genCreate();
+  }
+
+  function genCreate() {
     const meta = readMeta();
     const cols = collectColumns();
     const emp = Utils.getEmpId();
@@ -299,12 +323,124 @@ WHERE TABLE_ID = ${tableIdRef};`;
     Utils.toast(`SQL 생성 완료 · ${cols.length}개 컬럼`);
   }
 
+  function genDelete() {
+    const reason = Utils.getReason('change-reason');
+    const emp = Utils.getEmpId();
+    const schemaRaw    = (document.getElementById('tbl-d-schema').value || '').trim().toUpperCase();
+    const tableNameRaw = (document.getElementById('tbl-d-tableName').value || '').trim();
+    const mode = document.getElementById('tbl-d-mode').value;
+
+    const errs = [];
+    if (!reason) errs.push('상단 "변경 사유"를 입력하세요.');
+    if (!schemaRaw) errs.push('스키마명이 필요합니다.');
+    if (!tableNameRaw) errs.push('테이블명이 필요합니다.');
+    if (mode !== 'SOFT' && mode !== 'HARD') errs.push('삭제 처리 방식이 올바르지 않습니다.');
+    if (errs.length) { UI.showValidation(errs); return; }
+    UI.clearValidation();
+
+    const schema = schemaRaw;
+    const tbl    = Utils.ensurePrefix(tableNameRaw, 'TB');
+    const whereTbl   = `SCHEMA_NAME = ${Utils.q(schema)} AND TABLE_NAME = ${Utils.q(tbl)}`;
+    const tableIdRef = `(SELECT TABLE_ID FROM TB_META_TABLE WHERE ${whereTbl})`;
+
+    let out = '';
+    if (mode === 'SOFT') {
+      out += Utils.section(`테이블 소프트 삭제(DEPRECATED): ${schema}.${tbl}`);
+      out += `-- 실제 테이블/메타는 유지하고 STATUS_CD만 'DEPRECATED'로 표기합니다.\nUPDATE TB_META_TABLE
+   SET STATUS_CD = 'DEPRECATED',
+       ${Utils.auditCols(emp).update}
+ WHERE ${whereTbl};\n`;
+      const hist = Utils.snapshotHist({ kind:'TABLE', op:'U', reason, empId:emp, whereClause: whereTbl });
+      out += Utils.section('테이블 HIST INSERT (U, SOFT)') + hist + '\n\nCOMMIT;\n';
+      Utils.setOutput('tbl-output', out);
+      Utils.toast('테이블 SOFT 삭제 SQL 생성 완료');
+      return;
+    }
+
+    // HARD — 표준 §6.8 자식→부모 순서
+    if (!confirm(`표준 §6.8에 따라 ${schema}.${tbl}의 자식 메타(INDEX_COLUMN/INDEX/COLUMN) 및 본 테이블 메타가 모두 삭제되고 DROP TABLE이 수행됩니다.\n\n계속 진행하시겠습니까?`)) {
+      Utils.toast('취소되었습니다.');
+      return;
+    }
+
+    out += Utils.section(`테이블 하드 삭제(표준 §6.8): ${schema}.${tbl}`);
+    out += `-- ═══════════════════════════════════════════════════════════════════
+-- [경고] 테이블 HARD 삭제 — implicit commit 주의
+-- ───────────────────────────────────────────────────────────────────
+-- DROP TABLE 은 DDL이며 implicit commit을 동반합니다. 본 SQL의 어느
+-- 단계가 실패해도 이미 commit된 단계는 롤백되지 않습니다(SAVEPOINT
+-- 효과 없음). 자식 → 부모 순서가 깨지면 ORA-02292 또는 메타 부정합
+-- 위험이 있으므로 다음 순서를 반드시 유지하세요.
+--
+-- 표준 §6.8 순서:
+--   1) INDEX_COLUMN_HIST 적재 → DELETE
+--   2) INDEX_HIST 적재 → DELETE
+--   3) COLUMN_HIST 적재 → DELETE
+--   4) TABLE_HIST 적재 → DELETE
+--   5) DROP TABLE (물리)
+--
+-- 실패 발생 시 다음을 반드시 확인:
+--   1) HIST 적재 여부 (TB_META_*_HIST 4종)
+--   2) 메타 DELETE 여부 (TB_META_INDEX_COLUMN/INDEX/COLUMN/TABLE)
+--   3) Oracle 측 실제 테이블/인덱스 잔존 여부
+-- 부정합이 발견되면 수동 cleanup으로 일관성 회복하세요.
+-- ═══════════════════════════════════════════════════════════════════
+`;
+
+    // 1) INDEX_COLUMN HIST + DELETE — Utils.HIST_COLS에 미정의이므로 §6.8 raw SQL 인라인.
+    const indexColCols = ['INDEX_ID','COLUMN_POS','COLUMN_NAME','SORT_ORDER','FUNC_EXPRESSION'];
+    const indexColHist = `INSERT INTO TB_META_INDEX_COLUMN_HIST (
+    HIST_ID, HIST_TYPE, HIST_AT, HIST_BY, CHANGE_REASON,
+    ${indexColCols.join(', ')}
+)
+SELECT
+    SEQ_META_HIST_ID.NEXTVAL, 'D', SYSTIMESTAMP, ${Utils.q(emp)}, ${Utils.q(reason)},
+    ${indexColCols.map(c => 'mic.' + c).join(', ')}
+FROM TB_META_INDEX_COLUMN mic
+JOIN TB_META_INDEX mi ON mi.INDEX_ID = mic.INDEX_ID
+WHERE mi.TABLE_ID = ${tableIdRef};`;
+    out += Utils.section('1-1. 인덱스-컬럼 매핑 HIST INSERT (D)') + indexColHist + '\n';
+    out += Utils.section('1-2. 인덱스-컬럼 매핑 DELETE') + `DELETE FROM TB_META_INDEX_COLUMN
+ WHERE INDEX_ID IN (SELECT INDEX_ID FROM TB_META_INDEX WHERE TABLE_ID = ${tableIdRef});\n`;
+
+    // 2) INDEX HIST + DELETE
+    const indexHist = Utils.snapshotHist({
+      kind:'INDEX', op:'D', reason, empId:emp,
+      whereClause: `TABLE_ID = ${tableIdRef}`,
+    });
+    out += Utils.section('2-1. 인덱스 메타 HIST INSERT (D)') + indexHist + '\n';
+    out += Utils.section('2-2. 인덱스 메타 DELETE') + `DELETE FROM TB_META_INDEX WHERE TABLE_ID = ${tableIdRef};\n`;
+
+    // 3) COLUMN HIST + DELETE
+    const columnHist = Utils.snapshotHist({
+      kind:'COLUMN', op:'D', reason, empId:emp,
+      whereClause: `TABLE_ID = ${tableIdRef}`,
+    });
+    out += Utils.section('3-1. 컬럼 메타 HIST INSERT (D)') + columnHist + '\n';
+    out += Utils.section('3-2. 컬럼 메타 DELETE') + `DELETE FROM TB_META_COLUMN WHERE TABLE_ID = ${tableIdRef};\n`;
+
+    // 4) TABLE HIST + DELETE
+    const tableHist = Utils.snapshotHist({
+      kind:'TABLE', op:'D', reason, empId:emp,
+      whereClause: whereTbl,
+    });
+    out += Utils.section('4-1. 테이블 메타 HIST INSERT (D)') + tableHist + '\n';
+    out += Utils.section('4-2. 테이블 메타 DELETE') + `DELETE FROM TB_META_TABLE WHERE ${whereTbl};\n`;
+
+    // 5) DROP TABLE
+    out += Utils.section('5. 물리 DROP') + `DROP TABLE ${schema}.${tbl};\n\nCOMMIT;\n`;
+
+    Utils.setOutput('tbl-output', out);
+    Utils.toast('테이블 HARD 삭제 SQL 생성 완료');
+  }
+
   function clear() {
     if (!confirm('입력 내용을 모두 지울까요?')) return;
     renderBasic(); renderOwner(); renderRetention(); renderView();
     document.querySelector('#tbl-col-table tbody').innerHTML = '';
     colCounter = 0;
     addColumnRow();
+    renderDelete();
     Utils.setOutput('tbl-output', '');
     UI.clearValidation();
   }


### PR DESCRIPTION
## 변경
- **index.html**: 테이블 탭에 서브탭 추가 — 기존 '테이블 신규 생성'을 `#tbl-create` 패널로 감싸고, `#tbl-delete` 패널 신규 추가. 사이드바 nav / topbar / `app.js` `TAB_META` 라벨을 '테이블 생성·삭제' / 'CREATE/DROP TABLE · META DML · HIST'로 통일.
- **js/table.js**:
  - `renderDelete()` — schema/tableName/mode(SOFT|HARD) 입력 폼 (`column.js#renderDrop`과 동일한 raw HTML 패턴).
  - `generate()`를 active subtab 기반 디스패처로 변경, 기존 로직은 `genCreate()`로 분리.
  - `genDelete()` — SOFT는 `STATUS_CD='DEPRECATED'` UPDATE + `TABLE_HIST`(U), HARD는 표준 §6.8 자식→부모 순서로 `INDEX_COLUMN_HIST` → `INDEX_HIST` → `COLUMN_HIST` → `TABLE_HIST` 적재 + 각 단계 DELETE + `DROP TABLE`.
  - HARD 분기 시작에 implicit commit 경고 블록(PR #25/#26 스타일).
  - HARD 사전 `window.confirm()` 다이얼로그.
  - `clear()`도 새 패널 함께 클리어.
- `?v` 캐시 버스터 bump.

## 미진
- 메타-실제DB drift 감지(§8.x)는 별도 — 본 PR은 사용자 명령 SQL 생성 한정.
- HARD에서 시퀀스(`TB_META_SEQUENCE`) 정리는 `USED_FOR_TABLE`이 매칭되는 시퀀스만 후속 이슈에서 다룸.
- `Utils.HIST_COLS`에 `INDEX_COLUMN`이 없어 §6.8 첫 단계의 INDEX_COLUMN_HIST는 JOIN raw SQL로 인라인 작성. 후속 이슈에서 `utils.js`에 `INDEX_COLUMN` HIST 정의 추가하여 `snapshotHist`로 통합 가능.

Closes #14