### PR TITLE
fix(#3): NUMBER 타입에 length만 입력 시 검증 경고 추가

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -151,6 +151,9 @@ const ColumnTab = (() => {
     Utils.checkName('스키마명', t.schema, errs);
     Utils.checkName('테이블명', t.tableName ? Utils.ensurePrefix(t.tableName, 'TB') : '', errs);
     Utils.checkName('컬럼명', c.colName, errs);
+    if (c.dataType === 'NUMBER' && c.dataLength) {
+      errs.push('NUMBER 타입에 length 입력은 무시됩니다. precision/scale로 변경하세요.');
+    }
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 
@@ -224,6 +227,9 @@ const ColumnTab = (() => {
     Utils.checkName('스키마명', t.schema, errs);
     Utils.checkName('테이블명', t.tableName ? Utils.ensurePrefix(t.tableName, 'TB') : '', errs);
     Utils.checkName('컬럼명', c.colName, errs);
+    if (c.dataType === 'NUMBER' && c.dataLength) {
+      errs.push('NUMBER 타입에 length 입력은 무시됩니다. precision/scale로 변경하세요.');
+    }
     if (errs.length) { UI.showValidation(errs); return; }
     UI.clearValidation();
 

--- a/js/table.js
+++ b/js/table.js
@@ -207,7 +207,12 @@ const TableTab = (() => {
     Utils.checkName('스키마명', meta.schema, errors);
     Utils.checkName('테이블명', meta.tableName ? Utils.ensurePrefix(meta.tableName, 'TB') : '', errors);
     if (cols.length === 0) errors.push('컬럼을 1개 이상 추가하세요.');
-    cols.forEach((c, i) => Utils.checkName(`${i + 1}번 컬럼명`, c.colName, errors));
+    cols.forEach((c, i) => {
+      Utils.checkName(`${i + 1}번 컬럼명`, c.colName, errors);
+      if (c.dataType === 'NUMBER' && c.dataLength) {
+        errors.push(`${i+1}번 컬럼(${c.colName||''}): NUMBER 타입에 length 입력은 무시됩니다. precision/scale로 변경하세요.`);
+      }
+    });
     Utils.checkName('테이블스페이스', meta.tablespace, errors, false);
     if (meta.viewGenYn) Utils.checkName('뷰명', meta.viewName, errors, false);
     if (errors.length) { UI.showValidation(errors); return; }


### PR DESCRIPTION
## 변경
- js/table.js generate() 컬럼 검증: `c.dataType === 'NUMBER' && c.dataLength` 시 오류 메시지 'NUMBER 타입에 length 입력은 무시됩니다. precision/scale로 변경하세요.' 추가.
- js/column.js genAdd/genModify에 동일 가드 추가.
- js/utils.js typeDDL은 미변경 (NUMBER length 무시는 의도된 시맨틱).

## 효과
사용자가 NUMBER 타입에 length만 입력하는 silent drift를 사전 차단. precision 입력하라는 명시적 가이드.

Closes #3